### PR TITLE
Setting src and excluding generated graphql types

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,7 @@
 sonar.projectKey=mark-nygaard_the-motley-monkey
 sonar.organization=mark-nygaard
+sonar.sources=src/
+sonar.exclusions=src/lib/graphql.ts
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=The Motley Monkey


### PR DESCRIPTION
This pull request updates the SonarCloud configuration to include the `src/` directory as the source for analysis and excludes the `src/lib/graphql.ts` file. This ensures that the generated GraphQL types are not included in the analysis.